### PR TITLE
[Fix] DriftTime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 src/*.exe
-src/blackcoin
-src/blackcoind
-src/test_blackcoin
+src/stratis
+src/stratisd
+src/test_stratis
 src/build.h
 .*.swp
 *.*~*
@@ -10,11 +10,11 @@ src/build.h
 *.orig
 *.o
 *.patch
-.blackcoin
+.stratis
 #compilation and Qt preprocessor part
 *.qm
 Makefile
-blackcoin-qt
+stratis-qt
 #resources cpp
 qrc_*.cpp
 #qt creator

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+date
+ps axjf
+
+#################################################################
+# Update Ubuntu and install prerequisites for running Stratis   #
+#################################################################
+sudo apt-get update
+#################################################################
+# Build Stratis from source                                     #
+#################################################################
+NPROC=$(nproc)
+echo "nproc: $NPROC"
+#################################################################
+# Install all necessary packages for building Stratis           #
+#################################################################
+sudo apt-get install -y qt4-qmake libqt4-dev libminiupnpc-dev libdb++-dev libdb-dev libcrypto++-dev libqrencode-dev libboost-all-dev build-essential libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libssl-dev libdb++-dev libssl-dev ufw git
+sudo add-apt-repository -y ppa:bitcoin/bitcoin
+sudo apt-get update
+sudo apt-get install -y libdb4.8-dev libdb4.8++-dev
+
+cd /usr/local
+file=/usr/local/stratisX
+if [ ! -e "$file" ]
+then
+        sudo git clone https://github.com/stratisproject/stratisX.git
+fi
+
+cd /usr/local/stratisX/src
+file=/usr/local/stratisX/src/stratisd
+if [ ! -e "$file" ]
+then
+        sudo make -j$NPROC -f makefile.unix
+fi
+
+sudo cp /usr/local/stratisX/src/stratisd /usr/bin/stratisd
+
+################################################################
+# Configure to auto start at boot                                      #
+################################################################
+file=$HOME/.stratis
+if [ ! -e "$file" ]
+then
+        sudo mkdir $HOME/.stratis
+fi
+printf '%s\n%s\n%s\n%s\n' 'daemon=1' 'server=1' 'rpcuser=u' 'rpcpassword=p' | sudo tee $HOME/.stratis/stratis.conf
+file=/etc/init.d/stratis
+if [ ! -e "$file" ]
+then
+        printf '%s\n%s\n' '#!/bin/sh' 'sudo stratisd' | sudo tee /etc/init.d/stratis
+        sudo chmod +x /etc/init.d/stratis
+        sudo update-rc.d stratis defaults
+fi
+
+/usr/bin/stratisd
+echo "Stratis has been setup successfully and is running..."
+exit 0
+

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -33,7 +33,7 @@ namespace Checkpoints
         ( 100,    uint256("0x688468a8aa48cd1c2197e42e7d8acd42760b7e2ac4bcab9d18ac149a673e16f6") )
         ( 150,    uint256("0xe4ae9663519abec15e28f68bdb2cb89a739aee22f53d1573048d69141db6ee5d") )
         ( 127500, uint256("0x4773ca7512489df22de03aa03938412fab5b46154b05df004b97bcbeaa184078") )
-        ( 128943, uint256("0x36bcaa27a53d3adf22b2064150a297adb02ac39c24263a5ceb73856832d49679") ) // hardfork
+        ( 128943, uint256("0x36bcaa27a53d3adf22b2064150a297adb02ac39c24263a5ceb73856832d49679") ) 
     ;
 
     // TestNet has no checkpoints

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -27,11 +27,13 @@ namespace Checkpoints
     //
     static MapCheckpoints mapCheckpoints =
         boost::assign::map_list_of
-        (  0, uint256("0x0000066e91e46e5a264d42c89e1204963b2ee6be230b443e9159020539d972af") )
-        (  2, uint256("0xbca5936f638181e74a5f1e9999c95b0ce77da48c2688399e72bcc53a00c61eff") ) // Premine
-        ( 50, uint256("0x0353b43f4ce80bf24578e7c0141d90d7962fb3a4b4b4e5a17925ca95e943b816") )
-        (100, uint256("0x688468a8aa48cd1c2197e42e7d8acd42760b7e2ac4bcab9d18ac149a673e16f6") )
-        (150, uint256("0xe4ae9663519abec15e28f68bdb2cb89a739aee22f53d1573048d69141db6ee5d") )
+        (  0,     uint256("0x0000066e91e46e5a264d42c89e1204963b2ee6be230b443e9159020539d972af") )
+        (  2,     uint256("0xbca5936f638181e74a5f1e9999c95b0ce77da48c2688399e72bcc53a00c61eff") ) // Premine
+        ( 50,     uint256("0x0353b43f4ce80bf24578e7c0141d90d7962fb3a4b4b4e5a17925ca95e943b816") )
+        ( 100,    uint256("0x688468a8aa48cd1c2197e42e7d8acd42760b7e2ac4bcab9d18ac149a673e16f6") )
+        ( 150,    uint256("0xe4ae9663519abec15e28f68bdb2cb89a739aee22f53d1573048d69141db6ee5d") )
+        ( 127500, uint256("0x4773ca7512489df22de03aa03938412fab5b46154b05df004b97bcbeaa184078") )
+        ( 128943, uint256("0x36bcaa27a53d3adf22b2064150a297adb02ac39c24263a5ceb73856832d49679") ) // hardfork
     ;
 
     // TestNet has no checkpoints

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1932,20 +1932,8 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig) c
         return DoS(50, error("CheckBlock() : proof of work failed"));
 
     // Check timestamp
-
-//i added below
-//    map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.find(hashPrevBlock);
-//    if (mi == mapBlockIndex.end())
-//        return DoS(10, error("AcceptBlock() : prev block not found"));
-//    CBlockIndex* pindexPrev = (*mi).second;
-//    int nHeight = pindexPrev->nHeight+1;
-    if(nTime < 1479012252)
-      if (GetBlockTime() > FutureDriftV2(GetAdjustedTime()))
+    if (GetBlockTime() > FutureDriftV2(GetAdjustedTime()))
         return error("CheckBlock() : block timestamp too far in the future");
-    if(nTime >= 1479012253)
-      if (GetBlockTime() > FutureDriftV3(GetAdjustedTime()))
-        return error("CheckBlock() : block timestamp too far in the future");
-//end me add
 
     // First transaction must be coinbase, the rest must not be
     if (vtx.empty() || !vtx[0].IsCoinBase())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1932,8 +1932,20 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig) c
         return DoS(50, error("CheckBlock() : proof of work failed"));
 
     // Check timestamp
-    if (GetBlockTime() > FutureDriftV2(GetAdjustedTime()))
+
+//i added below
+//    map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.find(hashPrevBlock);
+//    if (mi == mapBlockIndex.end())
+//        return DoS(10, error("AcceptBlock() : prev block not found"));
+//    CBlockIndex* pindexPrev = (*mi).second;
+//    int nHeight = pindexPrev->nHeight+1;
+    if(nTime < 1479012252)
+      if (GetBlockTime() > FutureDriftV2(GetAdjustedTime()))
         return error("CheckBlock() : block timestamp too far in the future");
+    if(nTime >= 1479012253)
+      if (GetBlockTime() > FutureDriftV3(GetAdjustedTime()))
+        return error("CheckBlock() : block timestamp too far in the future");
+//end me add
 
     // First transaction must be coinbase, the rest must not be
     if (vtx.empty() || !vtx[0].IsCoinBase())

--- a/src/main.h
+++ b/src/main.h
@@ -59,9 +59,15 @@ inline bool IsProtocolV1RetargetingFixed(int nHeight) { return TestNet() || nHei
 inline bool IsProtocolV2(int nHeight) { return TestNet() || nHeight > 0; }
 inline bool IsProtocolV3(int64_t nTime) { return TestNet() || nTime > 1470467000; }
 
+inline bool IsDriftReduced(int64_t nTime) { return TestNet() || nTime > 1480118400; } // Drifting Bug Fix
+
+inline int64_t TestingDrift(int64_t nTime) { return nTime + 128 * 60 * 60; }
+inline int64_t MainNetDrift(int64_t nTime) { return nTime + 15; }
+
 inline int64_t FutureDriftV1(int64_t nTime) { return nTime + 10 * 60; }
-inline int64_t FutureDriftV2(int64_t nTime) { return nTime + 128*60*60; }
-inline int64_t FutureDriftV3(int64_t nTime) { return nTime + 15; }
+inline int64_t FutureDriftV2(int64_t nTime) {
+	return IsDriftReduced(nTime) ? MainNetDrift(nTime) : TestingDrift(nTime);
+}
 inline int64_t FutureDrift(int64_t nTime, int nHeight) { return IsProtocolV2(nHeight) ? FutureDriftV2(nTime) : FutureDriftV1(nTime); }
 
 inline unsigned int GetTargetSpacing(int nHeight) { return IsProtocolV2(nHeight) ? 64 : 60; }

--- a/src/main.h
+++ b/src/main.h
@@ -59,7 +59,7 @@ inline bool IsProtocolV1RetargetingFixed(int nHeight) { return TestNet() || nHei
 inline bool IsProtocolV2(int nHeight) { return TestNet() || nHeight > 0; }
 inline bool IsProtocolV3(int64_t nTime) { return TestNet() || nTime > 1470467000; }
 
-inline bool IsDriftReduced(int64_t nTime) { return TestNet() || nTime > 1480118400; } // Drifting Bug Fix
+inline bool IsDriftReduced(int64_t nTime) { return TestNet() || nTime > 1479513600; } // Drifting Bug Fix, hardfork on Sat, 19 Nov 2016 00:00:00 GMT
 
 inline int64_t TestingDrift(int64_t nTime) { return nTime + 128 * 60 * 60; }
 inline int64_t MainNetDrift(int64_t nTime) { return nTime + 15; }

--- a/src/main.h
+++ b/src/main.h
@@ -61,6 +61,7 @@ inline bool IsProtocolV3(int64_t nTime) { return TestNet() || nTime > 1470467000
 
 inline int64_t FutureDriftV1(int64_t nTime) { return nTime + 10 * 60; }
 inline int64_t FutureDriftV2(int64_t nTime) { return nTime + 128*60*60; }
+inline int64_t FutureDriftV3(int64_t nTime) { return nTime + 15; }
 inline int64_t FutureDrift(int64_t nTime, int nHeight) { return IsProtocolV2(nHeight) ? FutureDriftV2(nTime) : FutureDriftV1(nTime); }
 
 inline unsigned int GetTargetSpacing(int nHeight) { return IsProtocolV2(nHeight) ? 64 : 60; }


### PR DESCRIPTION
Closes bug where stakers can set time and stake blocks in the future. FutureDrift after hardfork will not allow blocks +15 seconds. This is a mandatory upgrade for **ALL** Stratis clients (Linux, Windows, and Mac). Binaries are on the way :)

Cleans up .gitignore and adds bash build script.

Added checkpoints