### PR TITLE
leave old fork behind

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -36,7 +36,7 @@ static const int PROTOCOL_VERSION = 70000;
 static const int INIT_PROTO_VERSION = 209;
 
 // disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 60018;
+static const int MIN_PEER_PROTO_VERSION = 70000;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this
@@ -53,7 +53,7 @@ static const int BIP0031_VERSION = 60000;
 static const int MEMPOOL_GD_VERSION = 60002;
 
 // reject blocks with non-canonical signatures starting from this version
-static const int CANONICAL_BLOCK_SIG_VERSION = 60018;
+static const int CANONICAL_BLOCK_SIG_VERSION = 70000;
 static const int CANONICAL_BLOCK_SIG_LOW_S_VERSION = 70000;
 
 #endif


### PR DESCRIPTION
No old clients affected with FutureDrift bug can connect.