### PR TITLE
Change the default maximum OP_RETURN size to 80 bytes

### DIFF
--- a/src/script.h
+++ b/src/script.h
@@ -23,7 +23,7 @@ typedef std::vector<unsigned char> valtype;
 class CTransaction;
 
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520; // bytes
-static const unsigned int MAX_OP_RETURN_RELAY = 40;      // bytes
+static const unsigned int MAX_OP_RETURN_RELAY = 80;      // bytes
 
 /** Signature hash types/flags */
 enum


### PR DESCRIPTION
The maximum size for OP_RETURN outputs is 40 bytes. I am proposing to increase it to 80 Bytes, Bitcoin has been operating with 80 Bytes for some time.

