### PR TITLE
Fix call of overloaded 'DbEvn(int)' is ambiguous

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -41,7 +41,7 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         LogPrintf("EnvShutdown exception: %s (%d)\n", DbEnv::strerror(ret), ret);
     if (!fMockDb)
-        DbEnv(0).remove(strPath.c_str(), 0);
+        DbEnv(0u).remove(strPath.c_str(), 0);
 }
 
 CDBEnv::CDBEnv() : dbenv(DB_CXX_NO_EXCEPTIONS)


### PR DESCRIPTION
When compiling with Berkeley DB 6.2.32, produces the following error:

```bash
db.cpp:44:16: error: call of overloaded ‘DbEnv(int)’ is ambiguous
         DbEnv(0).remove(strPath.c_str(), 0);
                ^
```
The literal 0 has two meanings in C++.
On the one hand, it is an integer with the value 0.
On the other hand, it is a null-pointer constant.

This is fixed by adding the suffix "u" which tells the compiler this is a unsigned integer. Then no conversion would be needed, and the call will be unambiguous.

This allows for compiling stratisX with Berkeley DB 6.2.32