### PR TITLE
Fix missing libz link flag for Stratis-qt build

### DIFF
--- a/stratis-qt.pro
+++ b/stratis-qt.pro
@@ -454,7 +454,7 @@ contains(RELEASE, 1) {
 
 !windows:!macx {
     DEFINES += LINUX
-    LIBS += -lrt -ldl
+    LIBS += -lrt -ldl -lz
 }
 
 system($$QMAKE_LRELEASE -silent $$_PRO_FILE_)


### PR DESCRIPTION
Produced build error when compiling with openssl1.0.2l (openssl compiled with zlib)

```bash
/usr/bin/ld: /home/ader/coins/DEPS/openssl1.0.2l/lib/libcrypto.a(c_zlib.o): undefined reference to symbol 'deflate'
//lib/x86_64-linux-gnu/libz.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:592: recipe for target 'stratis-qt' failed
make: *** [stratis-qt] Error 1
```
Simple fix is to add library link flag `-lz` to stratis-qt.pro

**Note: the flag is included in makefile.unix #L46***